### PR TITLE
Add kvikio / libkvikio to API docs

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -101,6 +101,17 @@ apis:
       legacy: 1
       stable: 1
       nightly: 1
+  kvikio:
+    name: kvikIO
+    path: kvikio
+    desc: "kvikIO is a Python library providing bindings to cuFile, which enables GPUDirectStore (GDS)."
+    ghlink: https://github.com/rapidsai/kvikio
+    cllink: https://github.com/rapidsai/kvikio/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
+      stable: 0
+      nightly: 1
   dask-cuda:
     name: Dask-CUDA
     path: dask-cuda
@@ -171,6 +182,17 @@ libs:
       # enable or disable links; 0 = disabled, 1 = enabled
       legacy: 1
       stable: 1
+      nightly: 1
+  libkvikio:
+    name: libkvikio
+    path: libkvikio
+    desc: "libkvikio is a C++ header-only library providing bindings to cuFile, which enables GPUDirectStorage (GDS)."
+    ghlink: https://github.com/rapidsai/kvikio
+    cllink: https://github.com/rapidsai/kvikio/blob/main/CHANGELOG.md
+    versions:
+      # enable or disable links; 0 = disabled, 1 = enabled
+      legacy: 0
+      stable: 0
       nightly: 1
   rapids-cmake:
     name: rapids-cmake


### PR DESCRIPTION
Adds kvikIO / libkvikio to the API docs, to follow up on the work to start building docs in https://github.com/rapidsai/kvikio/pull/31.